### PR TITLE
Allow setting of 'src' property on paper-fab elements

### DIFF
--- a/paper-fab-speed-dial-action.html
+++ b/paper-fab-speed-dial-action.html
@@ -56,7 +56,7 @@ Style                                                   | Description
 		</style>
 
 		<div class="flex"><span class="label"><slot></slot></span></div>
-		<paper-fab class="fab" icon=[[icon]] mini></paper-fab>
+		<paper-fab class="fab" icon$="[[icon]]" src$="[[src]]" mini></paper-fab>
 
 	</template>
 </dom-module>
@@ -71,7 +71,12 @@ Style                                                   | Description
 			/**
 			 * Icon that is shown next to the content
 			 */
-			icon: String
+			icon: String,
+			
+			/**
+			 * Custom icon using the paper-fab 'src' property
+			 */
+			src: String,
 		}
 	});
 

--- a/paper-fab-speed-dial-action.html
+++ b/paper-fab-speed-dial-action.html
@@ -43,11 +43,13 @@ Style                                                   | Description
 				padding: 5px 10px;
 				border-radius: 3px;
 				margin-right: 20px;
+				@apply --paper-fab-speed-dial-action-label;
 			}
 
 			.fab {
 				--paper-fab-background: var(--paper-fab-speed-dial-action-background);
 				--paper-fab-keyboard-focus-background: var(--paper-fab-speed-dial-action-keyboard-focus-background);
+				@apply --paper-fab-speed-dial-action-fab;
 			}
 
 			.label,.fab {

--- a/paper-fab-speed-dial.html
+++ b/paper-fab-speed-dial.html
@@ -40,6 +40,7 @@ Style                                            | Description
 			.open {
 				--paper-fab-background: var(--paper-fab-speed-dial-background);
 				--paper-fab-keyboard-focus-background: var(--paper-fab-speed-dial-keyboard-focus-background);
+				@apply --paper-fab-speed-dial-open;
 			}
 
 			.close {
@@ -47,6 +48,7 @@ Style                                            | Description
 				--paper-fab-keyboard-focus-background: var(--paper-fab-speed-dial-keyboard-focus-background, --paper-grey-500);
 				margin-top: 20px;
 				display: inline-block;
+				@apply --paper-fab-speed-dial-close;
 			}
 
 			.overlay {

--- a/paper-fab-speed-dial.html
+++ b/paper-fab-speed-dial.html
@@ -54,7 +54,7 @@ Style                                            | Description
 			}
 		</style>
 
-		<paper-fab icon="[[icon]]" class="open" on-tap="open" hidden$="[[opened]]" disabled="[[disabled]]"></paper-fab>
+		<paper-fab icon$="[[computedIcon]]" src$="[[src]]" class="open" on-tap="open" hidden$="[[opened]]" disabled="[[disabled]]"></paper-fab>
 
 		<paper-fab-speed-dial-overlay id="overlay" class="overlay" opened="{{opened}}" with-backdrop="[[withBackdrop]]">
 			<slot></slot>
@@ -72,8 +72,14 @@ Style                                            | Description
 		is: 'paper-fab-speed-dial',
 		properties: {
 			icon: {
+				type: String,	
+			},
+			computedIcon: {
 				type: String,
-				value: 'add'
+				computed: '_computeIcon(icon, src)'
+			},
+			src: {
+				type: String
 			},
 			opened: {
 				type: Boolean,
@@ -102,6 +108,12 @@ Style                                            | Description
 			}
 
 			this.opened = false;
+		},
+		
+		// Protected methods
+		_computeIcon: function(icon, src) {
+			// If we don't have an icon and we don't have a src then we default to the 'add' icon
+			return ((icon === undefined || icon === '') && (src === undefined || src === '')) ? 'add' : undefined;
 		},
 	});
 

--- a/paper-fab-speed-dial.html
+++ b/paper-fab-speed-dial.html
@@ -43,8 +43,8 @@ Style                                            | Description
 			}
 
 			.close {
-				--paper-fab-background: var(--paper-grey-500);
-				--paper-fab-keyboard-focus-background: var(--paper-grey-500);
+				--paper-fab-background: var(--paper-fab-speed-dial-background, --paper-grey-500);
+				--paper-fab-keyboard-focus-background: var(--paper-fab-speed-dial-keyboard-focus-background, --paper-grey-500);
 				margin-top: 20px;
 				display: inline-block;
 			}


### PR DESCRIPTION
Allows users of the element to set the 'src' property on the paper-fabs.

This introduces a computed property into <paper-fab-speed-dial> that allows the current behaviour of defaulting to the 'add' icon to continue.